### PR TITLE
[Week4] 토큰 인증 인터셉터 & Argument Resolver 구현

### DIFF
--- a/src/main/java/homeTry/annotation/LoginMember.java
+++ b/src/main/java/homeTry/annotation/LoginMember.java
@@ -1,0 +1,10 @@
+package homeTry.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember { }

--- a/src/main/java/homeTry/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/homeTry/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,44 @@
+package homeTry.auth;
+
+import homeTry.annotation.LoginMember;
+import homeTry.exception.clientException.BadRequestException;
+import homeTry.exception.clientException.UserNotFoundException;
+import homeTry.exception.serverException.InternalServerException;
+import homeTry.member.service.MemberService;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+    private final JwtAuth jwtAuth;
+
+    public LoginMemberArgumentResolver(MemberService memberService, JwtAuth jwtAuth) {
+        this.memberService = memberService;
+        this.jwtAuth = jwtAuth;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginMember.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        try{
+            String token = webRequest.getHeader("Authorization").substring(7);
+            String email = jwtAuth.extractEmail(token);
+            return memberService.getMember(email);
+        } catch (UserNotFoundException e) {
+            throw new UserNotFoundException("회원이 아닙니다.");
+        } catch (NullPointerException e){
+            throw new BadRequestException("토큰이 존재하지 않습니다.");
+        } catch (Exception e) {
+            throw new InternalServerException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/homeTry/config/WebMvcConfig.java
+++ b/src/main/java/homeTry/config/WebMvcConfig.java
@@ -1,0 +1,51 @@
+package homeTry.config;
+
+import homeTry.auth.JwtAuth;
+import homeTry.auth.LoginMemberArgumentResolver;
+import homeTry.interceptor.JwtInterceptor;
+import homeTry.member.service.MemberService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final MemberService memberService;
+    private final JwtInterceptor jwtInterceptor;
+    private final JwtAuth jwtAuth;
+
+    @Autowired
+    WebMvcConfig(MemberService memberService, JwtInterceptor jwtInterceptor, JwtAuth jwtAuth) {
+        this.memberService = memberService;
+        this.jwtInterceptor = jwtInterceptor;
+        this.jwtAuth = jwtAuth;
+    }
+
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/api/oauth/**");
+        //토큰 받는 경로 지정
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new LoginMemberArgumentResolver(memberService, jwtAuth));
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .exposedHeaders(HttpHeaders.LOCATION);
+    }
+}

--- a/src/main/java/homeTry/interceptor/JwtInterceptor.java
+++ b/src/main/java/homeTry/interceptor/JwtInterceptor.java
@@ -20,11 +20,6 @@ public class JwtInterceptor implements HandlerInterceptor {
             Object handler) throws Exception {
         String authHeader = request.getHeader("Authorization");
 
-/*        if ("GET".equalsIgnoreCase(request.getMethod()) &&
-                (request.getRequestURI().matches("/api/products(/\\d+)?"))) {
-            return true;
-        }*/
-
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
             if (jwtAuth.validateToken(token)) {

--- a/src/main/java/homeTry/interceptor/JwtInterceptor.java
+++ b/src/main/java/homeTry/interceptor/JwtInterceptor.java
@@ -1,0 +1,40 @@
+package homeTry.interceptor;
+
+import homeTry.auth.JwtAuth;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final JwtAuth jwtAuth;
+
+    public JwtInterceptor(JwtAuth jwtAuth) {
+        this.jwtAuth = jwtAuth;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+            Object handler) throws Exception {
+        String authHeader = request.getHeader("Authorization");
+
+/*        if ("GET".equalsIgnoreCase(request.getMethod()) &&
+                (request.getRequestURI().matches("/api/products(/\\d+)?"))) {
+            return true;
+        }*/
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtAuth.validateToken(token)) {
+                return true;
+            }
+        }
+
+        response.addHeader("WWW-Authenticate", "Bearer");
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        return false;
+    }
+
+}


### PR DESCRIPTION
## 토큰 인증 인터셉터를 언제 작동시킬지 설정하는 방법

`src/main/java/homeTry/config/WebMvcConfig.java`
여기의
```java
    @Override
    public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(jwtInterceptor)
                .addPathPatterns("/**")
                .excludePathPatterns("/api/oauth/**");
        //토큰 받는 경로 지정
    }
```
이 부분에서 토큰 받는 경로를 지정할 수 있습니다.

## 컨트롤러의 파라미터로 알아서 토큰을 MemberDTO로 바꿔서 받는법
예시)
```java
    public List<WishResponseDTO> getWishes(@LoginMember MemberDTO memberDTO) {
        return wishListService.getWishList(memberDTO);
    }
```
제가 구현한 ArgumentResolver 덕분에 컨트롤러 파라미터에 `@LoginMember MemberDTO memberDTO` 이것만 붙이시면 알아서 서버가 토큰을 회원정보로 바꿔서 회원정보가 파라미터로 들어옵니다.
