### PR TITLE
[Week10] TeamWithdrawService 책임 분산으로 인한 리팩토링

### DIFF
--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -336,8 +336,6 @@ public class TeamService {
         if (!team.validateIsLeader(memberId)) //팀 리더인지 체크
             throw new NotTeamLeaderException();
 
-        //chattingService.deleteTeamChattingMessageAll(team)
-
         teamMemberMappingService.deleteAllTeamMemberFromTeam(team); // 해당 팀에 대한 TeamMemberMapping 데이터 삭제
 
         teamTagMappingService.deleteAllTeamTagMappingFromTeam(team); //해당 팀에 대한 TeamTagMapping 데이터 삭제

--- a/src/main/java/homeTry/team/service/TeamWithdrawService.java
+++ b/src/main/java/homeTry/team/service/TeamWithdrawService.java
@@ -56,27 +56,4 @@ public class TeamWithdrawService {
 
         teamService.withdrawTeam(memberId, team);
     }
-
-    //회원 탈퇴로 인한 팀 삭제 처리 및 팀 탈퇴 처리
-    public void withdrawAllTeamsByMemberWithdraw(Long memberId) {
-        List<Team> teamList = teamService.getTeamListByLeaderId(memberId);
-
-        deleteTeamByTeamLeaderWithdraw(teamList, memberId);
-
-        withDrawAllTeams(teamList, memberId);
-    }
-
-    //회원탈퇴로 인한 해당 회원이 팀의 멤버로 속해있는 TeamMemberMapping에 대해 softDelete 적용
-    private void withDrawAllTeams(List<Team> teamList, Long memberId) {
-        teamList.forEach(
-                team -> withdrawTeam(memberId, team.getId())
-        );
-    }
-
-    //회원탈퇴로 인해 해당 회원이 팀 리더인 팀 일괄 삭제
-    private void deleteTeamByTeamLeaderWithdraw(List<Team> teamList, Long memberId) {
-        teamList.forEach(
-                team -> deleteTeam(memberId, team.getId())
-        );
-    }
 }


### PR DESCRIPTION
## 구현사항
TeamWithdrawService 는 멤버 탈퇴라는 사실을 모르게끔 기존에 있던 메소드를 삭제하고 온전히 팀 삭제와 팀 탈퇴를 수행하는 메소드만 남겨줌으로써 책임을 가볍게하고 코드 재사용성을 높임