### PR TITLE
[Week11] 랭킹 조회, 팀 조회 버그 수정

### DIFF
--- a/src/main/java/homeTry/team/dto/response/TagListResponse.java
+++ b/src/main/java/homeTry/team/dto/response/TagListResponse.java
@@ -1,5 +1,6 @@
 package homeTry.team.dto.response;
 
+import homeTry.tag.teamTag.dto.AllTeamTagDTO;
 import homeTry.tag.teamTag.dto.TeamTagDTO;
 
 import java.util.List;
@@ -9,4 +10,10 @@ public record TagListResponse(
         List<TeamTagDTO> ageTagList,
         List<TeamTagDTO> exerciseIntensityTagList
 ) {
+    public static TagListResponse of(AllTeamTagDTO allTeamTagDTO) {
+        return new TagListResponse(
+                allTeamTagDTO.genderTagList(),
+                allTeamTagDTO.ageTagList(),
+                allTeamTagDTO.exerciseIntensityTagList());
+    }
 }

--- a/src/main/java/homeTry/team/repository/TeamMemberMappingRepository.java
+++ b/src/main/java/homeTry/team/repository/TeamMemberMappingRepository.java
@@ -24,7 +24,12 @@ public interface TeamMemberMappingRepository extends JpaRepository<TeamMemberMap
 
     void deleteByTeam(Team team); //특정 팀에 속한 모든 엔티티 삭제
 
-    List<TeamMemberMapping> findByTeam(Team team);
+    @Query("SELECT tm " +
+            "FROM TeamMemberMapping tm " +
+            "WHERE tm.team = :team " +
+            "AND tm.isDeprecated = false"
+    )
+    List<TeamMemberMapping> findByTeam(@Param("team") Team team);
 
     @Query("SELECT tm " +
             "FROM TeamMemberMapping tm " +

--- a/src/main/java/homeTry/team/repository/TeamMemberMappingRepository.java
+++ b/src/main/java/homeTry/team/repository/TeamMemberMappingRepository.java
@@ -14,7 +14,13 @@ import java.util.Optional;
 
 public interface TeamMemberMappingRepository extends JpaRepository<TeamMemberMapping, Long> {
 
-    Optional<TeamMemberMapping> findByTeamAndMember(Team team, Member member);
+    @Query("SELECT tm " +
+            "FROM TeamMemberMapping tm " +
+            "WHERE tm.member = :member " +
+            "AND tm.team = :team " +
+            "AND tm.isDeprecated = false"
+    )
+    Optional<TeamMemberMapping> findByTeamAndMember(@Param("team") Team team, @Param("member") Member member);
 
     void deleteByTeam(Team team); //특정 팀에 속한 모든 엔티티 삭제
 

--- a/src/main/java/homeTry/team/repository/TeamRepository.java
+++ b/src/main/java/homeTry/team/repository/TeamRepository.java
@@ -21,7 +21,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "FROM Team t " +
             "WHERE t.id NOT IN (SELECT tm.team.id " +
             "                   FROM TeamMemberMapping tm " +
-            "                   WHERE tm.member = :member) " +
+            "                   WHERE tm.member = :member" +
+            "                   AND tm.isDeprecated = false) " +
             "AND t IN (SELECT tt.team " +
             "          FROM TeamTagMapping tt " +
             "          WHERE tt.teamTag IN :tagList " +
@@ -34,7 +35,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "FROM Team t " +
             "WHERE t.id NOT IN (SELECT tm.team.id " +
             "                   FROM TeamMemberMapping tm " +
-            "                   WHERE tm.member = :member) " +
+            "                   WHERE tm.member = :member" +
+            "                   AND tm.isDeprecated = false) " +
             "AND t IN (SELECT tt.team " +
             "          FROM TeamTagMapping tt " +
             "          WHERE tt.teamTag IN :tagList " +
@@ -48,7 +50,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "FROM Team t " +
             "WHERE t.id NOT IN (SELECT tm.team.id " +
             "                   FROM TeamMemberMapping tm " +
-            "                   WHERE tm.member = :member) " +
+            "                   WHERE tm.member = :member" +
+            "                   AND tm.isDeprecated = false) " +
             "AND t.teamName.value LIKE :teamName% "
     )
     Slice<Team> findByTeamNameExcludingMember(@Param("teamName") String teamName, @Param("member") Member member, Pageable pageable);
@@ -57,7 +60,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "FROM Team t " +
             "WHERE t.id NOT IN (SELECT tm.team.id " +
             "                   FROM TeamMemberMapping tm " +
-            "                   WHERE tm.member = :member) "
+            "                   WHERE tm.member = :member" +
+            "                   AND tm.isDeprecated = false) "
     )
     Slice<Team> findTeamExcludingMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/homeTry/team/repository/TeamRepository.java
+++ b/src/main/java/homeTry/team/repository/TeamRepository.java
@@ -60,6 +60,4 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "                   WHERE tm.member = :member) "
     )
     Slice<Team> findTeamExcludingMember(@Param("member") Member member, Pageable pageable);
-
-    List<Team> findByLeaderId(Long id);
 }

--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -210,6 +210,10 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);
 
+        Member member = memberService.getMemberEntity(memberDTO.id());
+
+        isMemberOfTeam(member, team); //유저가 팀에 속해있는지 확인
+
         List<Member> memberList = teamMemberMappingService.getMemberListByTeam(team); //팀의 멤버들을 조회해옴
 
         List<RankingDTO> rankingList = getRankingList(memberList, date); //랭킹을 구해옴
@@ -219,6 +223,11 @@ public class TeamService {
         Slice<RankingDTO> slice = getSlice(rankingList, pageable); // 슬라이싱 처리
 
         return new RankingResponse(myRanking.ranking(), myRanking.name(), myRanking.totalExerciseTime(), slice);
+    }
+
+    //유저가 해당 팀에 속해있는 멤버인지 조회
+    private void isMemberOfTeam(Member member, Team team) {
+        teamMemberMappingService.getTeamMemberMapping(team, member);
     }
 
     //리스트에 대해서 슬라이싱 처리해 주는 제네릭 메소드

--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -359,11 +359,6 @@ public class TeamService {
 
         team.decreaseParticipantsByWithdraw(); //팀의 현재 참여인원 감소
     }
-
-    public List<Team> getTeamListByLeaderId(Long memberId) {
-        return teamRepository.findByLeaderId(memberId);
-    }
-
 }
 
 

--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -237,7 +237,11 @@ public class TeamService {
                 .stream()
                 .filter(rankingDTO -> userNickname.equals(rankingDTO.name()))
                 .findFirst()
-                .orElseThrow(MyRankingNotFoundException::new);
+                .orElse(new RankingDTO(
+                        userNickname,
+                        DEFAULT_RANKING,
+                        0L
+                ));
     }
 
     //멤버 리스트에서 랭킹을 매겨주는 기능
@@ -255,6 +259,7 @@ public class TeamService {
 
         return totalExerciseTimeList //멤버들 랭킹 구함
                 .stream()
+                .filter(rankingDTO -> rankingDTO.totalExerciseTime() > 0) //기록이 없는 멥버들은 모두 제외
                 .sorted(Comparator.comparing(RankingDTO::totalExerciseTime).reversed())
                 .map(rankingDTO -> new RankingDTO(
                         rankingDTO.name(),
@@ -264,7 +269,7 @@ public class TeamService {
                 .toList();
     }
 
-    //멤버들의 오늘 totalExerciseTime 을 조회 후
+    //멤버들의 오늘 totalExerciseTime 을 조회
     private List<RankingDTO> getTotalExerciseTimeListOfToday(List<Member> memberList) {
         return memberList
                 .stream()

--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -197,11 +197,7 @@ public class TeamService {
     public TagListResponse getAllTeamTagList(MemberDTO memberDTO) {
         AllTeamTagDTO allTeamTagDTO = teamTagService.getAllTeamTagList(); //모든 태그 조회해 옴
 
-        return new TagListResponse(
-                allTeamTagDTO.genderTagList(),
-                allTeamTagDTO.ageTagList(),
-                allTeamTagDTO.exerciseIntensityTagList()
-        );
+        return TagListResponse.of(allTeamTagDTO);
     }
 
     //팀 랭킹 조회 기능(페이징 적용)


### PR DESCRIPTION
## 구현 사항
- 랭킹 조회 시 운동기록이 없는 유저는 랭킹에서 제외 
- 팀 탈퇴 후 그룹 탐색 시 탈퇴한 팀도 보이게끔 수정
- 랭킹 조회 시 팀에 속해있지 않은 멤버의 랭킹 조회 요청인 경우 거절
- `TeamMemberMapping` 에서 isDeprecated 컬럼값이 false인 데이터만 조회하도록 jpql 수정