### PR TITLE
[Week11] 팀 가입 및 팀 탈퇴 시 동시성 제어가 되도록 수정

### DIFF
--- a/src/main/java/homeTry/member/service/MemberTeamWithdrawService.java
+++ b/src/main/java/homeTry/member/service/MemberTeamWithdrawService.java
@@ -3,8 +3,10 @@ package homeTry.member.service;
 import homeTry.member.model.entity.Member;
 import homeTry.team.model.entity.Team;
 import homeTry.team.service.TeamMemberMappingService;
-import homeTry.team.service.TeamWithdrawService;
+import homeTry.team.service.TeamJoinAndWithdrawService;
+
 import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,13 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberTeamWithdrawService {
 
     private final TeamMemberMappingService teamMemberMappingService;
-    private final TeamWithdrawService teamWithdrawService;
+    private final TeamJoinAndWithdrawService teamJoinAndWithdrawService;
     private final MemberService memberService;
 
     public MemberTeamWithdrawService(TeamMemberMappingService teamMemberMappingService,
-            TeamWithdrawService teamWithdrawService, MemberService memberService) {
+                                     TeamJoinAndWithdrawService teamJoinAndWithdrawService, MemberService memberService) {
         this.teamMemberMappingService = teamMemberMappingService;
-        this.teamWithdrawService = teamWithdrawService;
+        this.teamJoinAndWithdrawService = teamJoinAndWithdrawService;
         this.memberService = memberService;
     }
 
@@ -29,11 +31,11 @@ public class MemberTeamWithdrawService {
         List<Team> withdrawTeamList = teamMemberMappingService.getTeamListByMember(withdrawMember);
 
         for (Team team : withdrawTeamList) {
-            if(team.getLeaderId().equals(withdrawMemberId)) {
-                teamWithdrawService.deleteTeam(withdrawMemberId, team.getId());
+            if (team.getLeaderId().equals(withdrawMemberId)) {
+                teamJoinAndWithdrawService.deleteTeam(withdrawMemberId, team.getId());
                 continue;
             }
-            teamWithdrawService.withdrawTeam(withdrawMemberId, team.getId());
+            teamJoinAndWithdrawService.withdrawTeam(withdrawMemberId, team.getId());
         }
     }
 

--- a/src/main/java/homeTry/team/controller/TeamController.java
+++ b/src/main/java/homeTry/team/controller/TeamController.java
@@ -9,7 +9,7 @@ import homeTry.team.dto.response.RankingResponse;
 import homeTry.team.dto.response.TagListResponse;
 import homeTry.team.dto.response.TeamResponse;
 import homeTry.team.service.TeamService;
-import homeTry.team.service.TeamWithdrawService;
+import homeTry.team.service.TeamJoinAndWithdrawService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,12 +32,12 @@ import java.util.List;
 public class TeamController {
 
     private final TeamService teamService;
-    private final TeamWithdrawService teamWithdrawService;
+    private final TeamJoinAndWithdrawService teamJoinAndWithdrawService;
 
     public TeamController(TeamService teamService,
-                          TeamWithdrawService teamWithdrawService) {
+                          TeamJoinAndWithdrawService teamJoinAndWithdrawService) {
         this.teamService = teamService;
-        this.teamWithdrawService = teamWithdrawService;
+        this.teamJoinAndWithdrawService = teamJoinAndWithdrawService;
     }
 
     //팀 생성 api
@@ -56,7 +56,7 @@ public class TeamController {
     @ApiResponse(responseCode = "204", description = "팀이 성공적으로 삭제됌")
     public ResponseEntity<Void> deleteTeam(@LoginMember MemberDTO memberDTO,
                                            @PathVariable("teamId") Long teamID) {
-        teamWithdrawService.deleteTeam(memberDTO.id(), teamID);
+        teamJoinAndWithdrawService.deleteTeam(memberDTO.id(), teamID);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -103,7 +103,7 @@ public class TeamController {
     public ResponseEntity<Void> joinTeam(
             @LoginMember MemberDTO memberDTO,
             @PathVariable("teamId") Long teamId) {
-        teamService.joinTeam(memberDTO, teamId);
+        teamJoinAndWithdrawService.joinTeam(memberDTO, teamId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -114,7 +114,7 @@ public class TeamController {
     public ResponseEntity<Void> withdrawTeam(
             @LoginMember MemberDTO memberDTO,
             @PathVariable("teamId") Long teamId) {
-        teamWithdrawService.withdrawTeam(memberDTO.id(), teamId);
+        teamJoinAndWithdrawService.withdrawTeam(memberDTO.id(), teamId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/homeTry/team/service/TeamJoinAndWithdrawService.java
+++ b/src/main/java/homeTry/team/service/TeamJoinAndWithdrawService.java
@@ -1,6 +1,7 @@
 package homeTry.team.service;
 
 import homeTry.chatting.service.ChattingService;
+import homeTry.member.dto.MemberDTO;
 import homeTry.member.service.MemberService;
 import homeTry.team.exception.badRequestException.TeamNotFoundException;
 import homeTry.team.model.entity.Team;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class TeamWithdrawService {
+public class TeamJoinAndWithdrawService {
     private final TeamService teamService;
     private final ChattingService chattingService;
     private final TeamRepository teamRepository;
@@ -17,7 +18,7 @@ public class TeamWithdrawService {
     private final TeamMemberMappingService teamMemberMappingService;
     private final TeamTagMappingService teamTagMappingService;
 
-    public TeamWithdrawService(
+    public TeamJoinAndWithdrawService(
             TeamService teamService,
             ChattingService chattingService,
             TeamRepository teamRepository,
@@ -32,6 +33,11 @@ public class TeamWithdrawService {
         this.teamTagMappingService = teamTagMappingService;
     }
 
+
+    public synchronized void joinTeam(MemberDTO memberDTO, Long teamId) {
+        teamService.joinTeam(memberDTO, teamId);
+    }
+
     //팀 삭제 기능
     @Transactional
     public void deleteTeam(Long memberId, Long teamId) {
@@ -43,9 +49,7 @@ public class TeamWithdrawService {
         teamService.deleteTeam(memberId, team);
     }
 
-    //팀 탈퇴 기능
-    @Transactional
-    public void withdrawTeam(Long memberId, Long teamId) {
+    public synchronized void withdrawTeam(Long memberId, Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);
 

--- a/src/main/java/homeTry/team/service/TeamService.java
+++ b/src/main/java/homeTry/team/service/TeamService.java
@@ -358,6 +358,7 @@ public class TeamService {
         teamRepository.delete(team); //Team 삭제
     }
 
+    @Transactional
     public void withdrawTeam(Long memberId, Team team) {
         Member member = memberService.getMemberEntity(memberId);
 


### PR DESCRIPTION
## 구현사항
- `TeamWithdrawService` -> `TeamJoinAndWithdrawService` 로 바꾸면서 팀 가입과 팀 탈퇴 시 `synchronized` 키워드를 통한 동기화가 적용된 메소드를 호출함으로써 값에 대한 수정 발생 시 동시성 제어가 이루어지게 함