### PR TITLE
[Week11] TeamMemberMapping 서비스 버그 수정 및, 팀 설명 길이 제한 구현

### DIFF
--- a/src/main/java/homeTry/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/homeTry/team/dto/request/TeamCreateRequest.java
@@ -13,7 +13,7 @@ public record TeamCreateRequest(
         String teamName,
 
         @NotBlank
-        @Size(min = 1, message = "팀 설명은 필수입니다.")
+        @Size(min = 1, max = 255, message = "팀 설명은 최소 1글자 최대 255글자 입니다")
         String teamDescription,
 
         @Min(value = 1, message = "최대 참여 인원은 1명 이상이여야 합니다")

--- a/src/main/java/homeTry/team/model/vo/Description.java
+++ b/src/main/java/homeTry/team/model/vo/Description.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record Description(String value) {
+    private static final int MAX_LENGTH = 255;
 
     public Description {
         validateDescription(value);
@@ -12,6 +13,10 @@ public record Description(String value) {
     private void validateDescription(String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("description은 빈 공백이면 안됩니다.");
+        }
+
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("description은 최대 255자 입니다");
         }
     }
 }


### PR DESCRIPTION
## 구현사항
- 이미 존재하는 TeamMemberMapping 데이터에 대해서 새로운 등록 요청 시 isDeprecated 값을 false로 정상적으로 전환되게 수정
- 팀 설명 길이 제한 최대 255글자 구현